### PR TITLE
fix ruby build error by specifying setup-ruby@v1

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -15,16 +15,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Setup enviroment
-        run: sudo apt-get install -y libxslt-dev libpq-dev libmagickwand-dev ghostscript gsfonts imagemagick ruby-rmagick libmagickcore-dev
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+
+      - name: Setup environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxslt-dev libpq-dev libmagickwand-dev ghostscript gsfonts imagemagick ruby-rmagick libmagickcore-dev
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
           bundler-cache: true
+
       - name: Set up database schema
         run: bin/rake db:migrate
+
       - name: Seed database with initial content
         run: bin/rake db:seed
+
       - name: Run tests
         run: bin/rake


### PR DESCRIPTION
The last PR build had an error, and copilot said to fix it by pinning the version (though this isn't what the build error says on the upstream-- there it says to run apt update)...